### PR TITLE
feat: add reusable button component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useCallback } from 'react';
-import { 
-  Upload, FileText, Image, Video, Settings, Download, Check, AlertCircle, 
+import {
+  Upload, FileText, Image, Video, Settings, Download, Check, AlertCircle,
   Trash2, Edit2, Save, Archive, Sparkles
 } from 'lucide-react';
 import JSZip from 'jszip';
+import Button from './components/Button';
 
 const CreativeChecker = () => {
   const [files, setFiles] = useState([]);
@@ -973,31 +974,32 @@ const CreativeChecker = () => {
             { id: 'upload', label: 'Upload & Validate', icon: Upload, description: 'Upload and analyze creatives' },
             { id: 'settings', label: 'Spec Management', icon: Settings, description: 'Configure validation rules' }
           ].map(({ id, label, icon: Icon, description }) => (
-            <button
+            <Button
               key={id}
               onClick={() => setActiveTab(id)}
+              variant={activeTab === id ? 'primary' : 'secondary'}
               className={`group relative px-6 py-4 rounded-2xl flex items-center space-x-3 transition-all duration-200 ${
-                activeTab === id 
-                  ? 'bg-gradient-to-r from-[#cf0e0f] to-red-700 text-white shadow-lg shadow-red-500/25 scale-105' 
-                  : 'bg-white/70 text-gray-600 hover:bg-white hover:shadow-md backdrop-blur-sm'
+                activeTab === id ? 'scale-105' : 'backdrop-blur-sm'
               }`}
             >
-              <div className={`p-2 rounded-lg ${
-                activeTab === id 
-                  ? 'bg-white/20' 
-                  : 'bg-gray-100 group-hover:bg-gray-200'
-              }`}>
+              <div
+                className={`p-2 rounded-lg ${
+                  activeTab === id ? 'bg-white/20' : 'bg-gray-100 group-hover:bg-gray-200'
+                }`}
+              >
                 <Icon className="w-5 h-5" />
               </div>
               <div className="text-left">
                 <div className="font-semibold">{label}</div>
-                <div className={`text-xs ${
-                  activeTab === id 
-                    ? 'text-blue-100' 
-                    : 'text-gray-500'
-                }`}>{description}</div>
+                <div
+                  className={`text-xs ${
+                    activeTab === id ? 'text-blue-100' : 'text-gray-500'
+                  }`}
+                >
+                  {description}
+                </div>
               </div>
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -1114,27 +1116,24 @@ const CreativeChecker = () => {
                     </div>
                   )}
                   
-                  <button
+                  <Button
                     onClick={() => fileInputRef.current?.click()}
                     disabled={isProcessing}
-                    className={`px-8 py-4 rounded-xl font-semibold transition-all duration-200 ${
-                      isProcessing
-                        ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                        : 'bg-gradient-to-r from-[#cf0e0f] to-red-700 hover:from-red-700 hover:to-red-800 text-white shadow-lg hover:shadow-xl transform hover:scale-105'
-                    }`}
+                    variant="primary"
+                    className="px-8 py-4 flex items-center justify-center space-x-2"
                   >
                     {isProcessing ? (
-                      <div className="flex items-center space-x-2">
+                      <>
                         <div className="animate-spin rounded-full h-4 w-4 border-2 border-gray-400 border-t-transparent"></div>
                         <span>Processing...</span>
-                      </div>
+                      </>
                     ) : (
-                      <div className="flex items-center space-x-2">
+                      <>
                         <Upload className="w-5 h-5" />
                         <span>Choose Files to Upload</span>
-                      </div>
+                      </>
                     )}
-                  </button>
+                  </Button>
                   
                   <input
                     ref={fileInputRef}
@@ -1157,20 +1156,22 @@ const CreativeChecker = () => {
                     <p className="text-gray-600">Comprehensive analysis of your creative assets</p>
                   </div>
                   <div className="flex space-x-3">
-                    <button 
+                    <Button
                       onClick={downloadCSV}
-                      className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-xl font-semibold transition-all duration-200 flex items-center space-x-2 shadow-lg hover:shadow-xl transform hover:scale-105"
+                      variant="secondary"
+                      className="px-4 py-2 flex items-center space-x-2 bg-green-600 hover:bg-green-700 text-white"
                     >
                       <Download className="w-4 h-4" />
                       <span>Export CSV</span>
-                    </button>
-                    <button 
+                    </Button>
+                    <Button
                       onClick={downloadResults}
-                      className="px-4 py-2 bg-[#cf0e0f] hover:bg-red-700 text-white rounded-xl font-semibold transition-all duration-200 flex items-center space-x-2 shadow-lg hover:shadow-xl transform hover:scale-105"
+                      variant="danger"
+                      className="px-4 py-2 flex items-center space-x-2"
                     >
                       <Download className="w-4 h-4" />
                       <span>Export JSON</span>
-                    </button>
+                    </Button>
                   </div>
                 </div>
                 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const VARIANTS = {
+  primary: 'bg-[#cf0e0f] hover:bg-red-700 text-white',
+  secondary: 'bg-gray-100 hover:bg-gray-200 text-gray-700',
+  danger: 'bg-red-600 hover:bg-red-700 text-white'
+};
+
+const Button = ({ variant = 'primary', className = '', children, ...props }) => {
+  const base = 'rounded-xl font-semibold transition-colors duration-200 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed';
+  const variantClasses = VARIANTS[variant] || VARIANTS.primary;
+  return (
+    <button className={`${base} ${variantClasses} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
## Summary
- add generic Button component with primary, secondary and danger variants
- swap navigation, upload and export buttons to use new component and drop gradients for solid colors

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a56b62fd008325958f4184e992da01